### PR TITLE
fix anchor self-links

### DIFF
--- a/API-Reference.md
+++ b/API-Reference.md
@@ -25,7 +25,7 @@ import * as topojson from "topojson";
 
 See [client.js](https://github.com/mbostock/topojson/blob/master/client.js) for a list of exported symbols. Note that there is no default export, so `import topojson from "topojson"` won’t work!
 
-<a name="feature" href="#wiki-feature">#</a> topojson.<b>feature</b>(<i>topology</i>, <i>object</i>)
+<a name="feature" href="#feature">#</a> topojson.<b>feature</b>(<i>topology</i>, <i>object</i>)
 
 Returns the GeoJSON Feature or FeatureCollection for the specified *object* in the given *topology*. If the specified object is a GeometryCollection, a FeatureCollection is returned, and each geometry in the collection is mapped to a Feature. Otherwise, a Feature is returned.
 
@@ -39,15 +39,15 @@ Some examples:
 
 See [the tests](https://github.com/mbostock/topojson/blob/master/test/feature-test.js) for more examples.
 
-<a name="merge" href="#wiki-merge">#</a> topojson.<b>merge</b>(<i>topology</i>, <i>objects</i>)
+<a name="merge" href="#merge">#</a> topojson.<b>merge</b>(<i>topology</i>, <i>objects</i>)
 
 Returns the GeoJSON MultiPolygon geometry object representing the union for the specified array of Polygon and MultiPolygon *objects* in the given *topology*. Interior borders shared by adjacent polygons are removed. See [Merging States](http://bl.ocks.org/mbostock/5416405) for an example.
 
-<a name="mergeArcs" href="#wiki-mergeArcs">#</a> topojson.<b>mergeArcs</b>(<i>topology</i>, <i>objects</i>)
+<a name="mergeArcs" href="#mergeArcs">#</a> topojson.<b>mergeArcs</b>(<i>topology</i>, <i>objects</i>)
 
-Equivalent to [topojson.merge](#wiki-merge), but returns a TopoJSON MultiPolygon object rather than GeoJSON.
+Equivalent to [topojson.merge](#merge), but returns a TopoJSON MultiPolygon object rather than GeoJSON.
 
-<a name="mesh" href="#wiki-mesh">#</a> topojson.<b>mesh</b>(<i>topology</i>, <i>object</i>, [<i>filter</i>])
+<a name="mesh" href="#mesh">#</a> topojson.<b>mesh</b>(<i>topology</i>, <i>object</i>, [<i>filter</i>])
 
 Returns the GeoJSON MultiLineString geometry object representing the mesh for the specified *object* in the given *topology*. This is useful for rendering strokes in complicated objects efficiently, as edges that are shared by multiple features are only stroked once.
 
@@ -57,19 +57,19 @@ An optional *filter* function may be specified to prune arcs from the returned m
 var interiors = topojson.mesh(topology, object, function(a, b) { return a !== b; });
 ```
 
-See [this county choropleth](http://bl.ocks.org/mbostock/4060606) for example. Note: the *a* and *b* objects are TopoJSON objects (pulled directly from the topology), and not automatically converted to GeoJSON features as by [topojson.feature](#wiki-feature).
+See [this county choropleth](http://bl.ocks.org/mbostock/4060606) for example. Note: the *a* and *b* objects are TopoJSON objects (pulled directly from the topology), and not automatically converted to GeoJSON features as by [topojson.feature](#feature).
 
-<a name="meshArcs" href="#wiki-meshArcs">#</a> topojson.<b>meshArcs</b>(<i>topology</i>[, <i>objects</i>[, <i>filter</i>]])
+<a name="meshArcs" href="#meshArcs">#</a> topojson.<b>meshArcs</b>(<i>topology</i>[, <i>objects</i>[, <i>filter</i>]])
 
-Equivalent to [topojson.mesh](#wiki-mesh), but returns a TopoJSON MultiLineString object rather than GeoJSON.
+Equivalent to [topojson.mesh](#mesh), but returns a TopoJSON MultiLineString object rather than GeoJSON.
 
-<a name="neighbors" href="#wiki-neighbors">#</a> topojson.<b>neighbors</b>(<i>objects</i>)
+<a name="neighbors" href="#neighbors">#</a> topojson.<b>neighbors</b>(<i>objects</i>)
 
 Returns an array representing the set of neighboring objects for each object in the specified *objects* array. The returned array has the same number of elements as the input array; each element *i* in the returned array is the array of indexes for neighbors of object *i* in the input array. For example, if the specified objects array contains the features *foo* and *bar*, and these features are neighbors, the returned array will be [​[1], [0]​], indicating that *foo* is a neighbor of *bar* and *vice versa*. Each array of neighbor indexes for each object is guaranteed to be sorted in ascending order.
 
 For a practical example, see the [world map](http://bl.ocks.org/mbostock/4180634) with topological coloring.
 
-<a name="presimplify" href="#wiki-presimplify">#</a> topojson.<b>presimplify</b>(<i>topojson</i>[, <i>triangleArea</i>])
+<a name="presimplify" href="#presimplify">#</a> topojson.<b>presimplify</b>(<i>topojson</i>[, <i>triangleArea</i>])
 
 …
 
@@ -87,7 +87,7 @@ Then, to require:
 var topojson = require("topojson");
 ```
 
-<a name="topology" href="#wiki-topology">#</a> topojson.<b>topology</b>(<i>objects</i>[, <i>options</i>])
+<a name="topology" href="#topology">#</a> topojson.<b>topology</b>(<i>objects</i>[, <i>options</i>])
 
 Returns the TopoJSON topology representing the merger of the specified map of GeoJSON *objects*. The returned topology’s `objects` will contain an object for each feature, feature collection or geometry in the specified map. For example, if you want to convert a single GeoJSON feature collection to TopoJSON:
 
@@ -147,20 +147,20 @@ If the property transform function returns null or an empty object, then the out
 
 Note that the input to `topojson.topology` is modified in-place, so if you intend to use the GeoJSON input after creating a TopoJSON representation, clone the input first.
 
-<a href="#wiki-simplify" name="simplify">#</a> topojson.<b>simplify</b>(<i>topology</i>[, <i>options</i>])
+<a href="#simplify" name="simplify">#</a> topojson.<b>simplify</b>(<i>topology</i>[, <i>options</i>])
 
 …
 
-<a href="#wiki-prune" name="prune">#</a> topojson.<b>prune</b>(<i>topology</i>[, <i>options</i>])
+<a href="#prune" name="prune">#</a> topojson.<b>prune</b>(<i>topology</i>[, <i>options</i>])
 
 Removes any unused arcs from the specified topology. The following *options* may be specified:
 
 * verbose - if truthy, informational messages will be output to stderr.
 
-<a href="#wiki-filter" name="filter">#</a> topojson.<b>filter</b>(<i>topology</i>[, <i>options</i>])
+<a href="#filter" name="filter">#</a> topojson.<b>filter</b>(<i>topology</i>[, <i>options</i>])
 
 …
 
-<a href="#wiki-bind" name="bind">#</a> topojson.<b>bind</b>(<i>topology</i>, <i>propertiesById</i>)
+<a href="#bind" name="bind">#</a> topojson.<b>bind</b>(<i>topology</i>, <i>propertiesById</i>)
 
 …

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TopoJSON 1.x API Reference
 
-This is an archive of the [TopoJSON 1.x API Reference](https://github.com/topojson/topojson-3.x-api-reference/blob/master/API-Reference.md) from the [TopoJSON wiki](https://github.com/topojson/topojson/wiki).
+This is an archive of the TopoJSON 1.x API Reference from the [TopoJSON wiki](https://github.com/topojson/topojson/wiki).
 
 For the current version of TopoJSON, see the [TopoJSON API Reference](https://github.com/topojson/topojson/blob/master/README.md).


### PR DESCRIPTION
This is even more obscure, but I suppose there may be people who still use the 1.0 docs, and apparently the dc.js documentation still points to it.

There was also one link to future documentation (!) which was probably an overzealous search & replace from the d3 side of things.